### PR TITLE
Fix scaling mismatch in image translator

### DIFF
--- a/dev-image_translator/image_translator.py
+++ b/dev-image_translator/image_translator.py
@@ -9,6 +9,8 @@ displayed near the cursor.
 from pynput import mouse
 from PIL import Image
 
+import ctypes
+
 import win32gui
 import win32ui
 import win32con
@@ -19,6 +21,12 @@ from math import sin
 import pytesseract
 
 pytesseract.pytesseract.tesseract_cmd = r'C:\Program Files\Tesseract-OCR\tesseract.exe'
+
+try:
+    ctypes.windll.user32.SetProcessDPIAware()
+except Exception:
+    # Fallback for older Windows versions or missing attribute
+    pass
 
 from translate import Translator
 


### PR DESCRIPTION
## Summary
- make the image translator process DPI aware to sync highlight and screenshot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c1074796883248b06483d03a27396