### PR TITLE
Implement DeepSeek chat history compressor

### DIFF
--- a/dev-group_supervisor/README.md
+++ b/dev-group_supervisor/README.md
@@ -1,1 +1,8 @@
 # dev-group_supervisor
+
+Utilities for automating routine tasks around development. The
+`chat_history_compressor.py` module provides a `ChatHistoryCompressor`
+class which uses the DeepSeek Reasoner API to recursively compress a
+long OpenAI chat history. It keeps important dates and numbers intact
+while summarising each block until the history fits within two thirds
+of the target model token limit.

--- a/dev-group_supervisor/chat_history_compressor.py
+++ b/dev-group_supervisor/chat_history_compressor.py
@@ -1,0 +1,83 @@
+"""Utilities for compressing long chat histories using DeepSeek Reasoner."""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import List, Dict
+
+import requests
+import tiktoken
+
+
+class ChatHistoryCompressor:
+    """Compress chat history recursively using the DeepSeek Reasoner API."""
+
+    def __init__(self, api_key: str, model: str = "deepseek-chat") -> None:
+        self.api_key = api_key
+        self.model = model
+        self.encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
+        self._log = logging.getLogger(self.__class__.__name__)
+
+    def _count_tokens(self, messages: List[Dict[str, str]]) -> int:
+        """Count tokens for a list of OpenAI style messages."""
+        tokens_per_message = 4
+        tokens_per_name = -1
+        total = 0
+        for m in messages:
+            total += tokens_per_message
+            for k, v in m.items():
+                total += len(self.encoding.encode(v))
+                if k == "name":
+                    total += tokens_per_name
+        return total + 2
+
+    def _split_blocks(self, messages: List[Dict[str, str]], block_token_limit: int) -> List[List[Dict[str, str]]]:
+        blocks: List[List[Dict[str, str]]] = []
+        current: List[Dict[str, str]] = []
+        tokens = 0
+        for msg in messages:
+            msg_tokens = self._count_tokens([msg])
+            if tokens + msg_tokens > block_token_limit and current:
+                blocks.append(current)
+                current = [msg]
+                tokens = msg_tokens
+            else:
+                current.append(msg)
+                tokens += msg_tokens
+        if current:
+            blocks.append(current)
+        return blocks
+
+    def _compress_block(self, block: List[Dict[str, str]]) -> Dict[str, str]:
+        text = "\n".join(f"{m['role']}: {m['content']}" for m in block)
+        prompt = (
+            "Сожми следующие сообщения без потери смысла и важной информации дат "
+            "и чисел. Сформулируй суть коротко на русском:\n" + text
+        )
+        url = "https://api.deepseek.com/v1/chat/completions"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.1,
+        }
+        self._log.debug("Requesting DeepSeek compression")
+        resp = requests.post(url, headers=headers, json=payload, timeout=60)
+        resp.raise_for_status()
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"]
+        return {"role": "system", "content": content.strip()}
+
+    def compress_messages(self, messages: List[Dict[str, str]], max_model_tokens: int) -> List[Dict[str, str]]:
+        """Recursively compress ``messages`` to fit under 2/3 of ``max_model_tokens``."""
+        limit = math.floor(max_model_tokens * (2 / 3))
+        compressed = list(messages)
+        while self._count_tokens(compressed) > limit:
+            block_limit = max(256, limit // 2)
+            blocks = self._split_blocks(compressed, block_limit)
+            compressed = [self._compress_block(b) for b in blocks]
+        return compressed


### PR DESCRIPTION
## Summary
- add ChatHistoryCompressor class for condensing long OpenAI-format conversations using the DeepSeek Reasoner API
- document new module in dev-group_supervisor README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1668c5b48324a1367fd060069166