### PR TITLE
Improve screenshot path handling

### DIFF
--- a/dev-image_translator/image_translator.py
+++ b/dev-image_translator/image_translator.py
@@ -9,6 +9,7 @@
 
 from pynput import mouse, keyboard
 from PIL import Image
+import os
 
 import ctypes
 
@@ -74,8 +75,10 @@ class Screenshot:
     """Функции для создания скриншотов через WinAPI."""
 
     @classmethod
-    def grab(cls, rect, bmp_filename=r".\screenshots\screenshot.bmp", hwnd=0):
+    def grab(cls, rect, bmp_filename=None, hwnd=0):
         """Захватывает прямоугольную область экрана и сохраняет её в ``bmp_filename``."""
+        if bmp_filename is None:
+            bmp_filename = os.path.join(os.path.dirname(__file__), "screenshots", "screenshot.bmp")
         window_dc = win32gui.GetWindowDC(hwnd)
         dc_object = win32ui.CreateDCFromHandle(window_dc)
         compatible_dc = dc_object.CreateCompatibleDC()

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from pathlib import Path
 import unittest
 import importlib.util
 
@@ -23,15 +24,15 @@ except Exception:
 class TestScreenshot(unittest.TestCase):
     @unittest.skipUnless(AVAILABLE, 'Screenshot functionality not available')
     def test_grab_creates_file(self):
-        tmp_file = os.path.join(tempfile.gettempdir(), 'test_screenshot.bmp')
-        if os.path.exists(tmp_file):
-            os.remove(tmp_file)
+        tmp_file = Path(tempfile.gettempdir()) / 'test_screenshot.bmp'
+        if tmp_file.exists():
+            tmp_file.unlink()
         try:
             Screenshot.grab((0, 0, 10, 10), tmp_file)
-            self.assertTrue(os.path.exists(tmp_file))
+            self.assertTrue(tmp_file.exists())
         finally:
-            if os.path.exists(tmp_file):
-                os.remove(tmp_file)
+            if tmp_file.exists():
+                tmp_file.unlink()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- construct screenshot default path with `os.path.join`
- use `pathlib.Path` in screenshot tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3efb751883248ee30c9c6a85af65