### PR TITLE
Fix layered surface size handling

### DIFF
--- a/dev-image_translator/image_translator.py
+++ b/dev-image_translator/image_translator.py
@@ -375,10 +375,13 @@ class ImageTranslatorApp:
                 Window.set_position(self.cursor_position[0] + 22, self.cursor_position[1] + 24)
                 Window.set_size(self.w, self.h)
 
+                surface_to_update = self.screen.subsurface((0, 0, self.w, self.h))
+                surface_to_update.fill((0, 0, 0, 0))
+
                 if self.text and self.text != ["..."]:
                     bg = self.pygame.Surface((self.w, self.h), self.pygame.SRCALPHA)
                     bg.fill((32, 32, 32, int(200 * self.fade)))
-                    self.screen.blit(bg, (0, 0))
+                    surface_to_update.blit(bg, (0, 0))
 
                     total_h = sum(s[1] for s in self.text_size)
                     y = (self.h - total_h) // 2
@@ -386,25 +389,25 @@ class ImageTranslatorApp:
                         surf = self.font.render(line, False, blink_color)
                         surf.set_alpha(int(255 * self.fade))
                         x = (self.w - size[0]) // 2
-                        self.screen.blit(surf, (x, y))
+                        surface_to_update.blit(surf, (x, y))
                         y += size[1]
 
-                LayeredWindow.update(self.screen)
-                self.screen.fill((0, 0, 0, 0))
+                LayeredWindow.update(surface_to_update)
             else:
                 left, top, width, height = self.current_drag_rect
 
                 Window.set_position(left - 1, top - 1)
                 Window.set_size(width + 2, height + 2)
-                self.screen.fill((0, 0, 0, 0))
+                surface_to_update = self.screen.subsurface((0, 0, width + 2, height + 2))
+                surface_to_update.fill((0, 0, 0, 0))
 
                 pygame.draw.rect(
-                    self.screen,
+                    surface_to_update,
                     blink_color,
                     (1, 1, width, height),
                     2,
                 )
-                LayeredWindow.update(self.screen)
+                LayeredWindow.update(surface_to_update)
 
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:


### PR DESCRIPTION
## Summary
- update `ImageTranslatorApp.run` to draw onto a surface that matches the window size
- clear only the subsurface each frame

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c48392cbc8324a4e52411c2c60af8