### PR TITLE
Add platform checks for Windows-only utilities

### DIFF
--- a/dev-image_translator/image_translator.py
+++ b/dev-image_translator/image_translator.py
@@ -7,16 +7,29 @@
 Переведённый текст отображается рядом с курсором.
 """
 
-from pynput import mouse, keyboard
-from PIL import Image
+import sys
 import os
+from PIL import Image
 
 import ctypes
 
-import win32gui
-import win32ui
-import win32con
-import win32api
+WINDOWS = sys.platform.startswith("win")
+
+if WINDOWS:
+    from pynput import mouse, keyboard
+    try:
+        import win32gui
+        import win32ui
+        import win32con
+        import win32api
+    except ImportError as exc:  # pragma: no cover - platform specific
+        raise ImportError(
+            "Required Windows dependencies are missing: {}".format(exc)
+        ) from exc
+else:  # pragma: no cover - platform specific
+    raise ImportError(
+        "The image_translator module only supports Windows platforms"
+    )
 
 from math import sin
 

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 from pathlib import Path
 import unittest
@@ -22,7 +23,10 @@ except Exception:
     Screenshot = None
 
 class TestScreenshot(unittest.TestCase):
-    @unittest.skipUnless(AVAILABLE, 'Screenshot functionality not available')
+    @unittest.skipUnless(
+        sys.platform.startswith('win') and AVAILABLE,
+        'Screenshot functionality not available',
+    )
     def test_grab_creates_file(self):
         tmp_file = Path(tempfile.gettempdir()) / 'test_screenshot.bmp'
         if tmp_file.exists():


### PR DESCRIPTION
## Summary
- guard Windows-only imports in `image_translator.py`
- surface clear error when importing on non-Windows
- skip screenshot tests when not on Windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c48669edc83248457d6c4844a967f