### PR TITLE
Add English README and document env vars

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,46 @@
+## About the project
+
+A small collection of experimental Python scripts. Some of them may be rough but demonstrate interesting ideas.
+
+* **Image Translator** – uses WinAPI to capture a selected screen region, recognizes English text with OCR, translates it into Russian and displays the result on top of other windows.
+
+This file is an English translation of the main [README](README.md).
+
+## Requirements
+
+- Python 3.8 or newer;
+- Windows is required for the Image Translator module (it relies on WinAPI);
+- packages listed in `requirements.txt`.
+
+Some modules rely on environment variables (see below).
+
+## Installing dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage examples
+
+Image Translator:
+
+```bash
+set TESSERACT_CMD=C:\\Program Files\\Tesseract-OCR\\tesseract.exe
+python dev-image_translator/image_translator.py
+```
+
+Image generation via StabilityAI:
+
+```bash
+set _STABILITYAI_API_KEY_1=your_api_key
+python dev-stability_ai/_stabilityai_stableimage_generator.py
+```
+
+## Environment variables
+
+- `TESSERACT_CMD` – path to the `tesseract.exe` executable used by the *Image Translator* module. Defaults to `C:\Program Files\Tesseract-OCR\tesseract.exe` if not set.
+- `_STABILITYAI_API_KEY_1` – API key for the StabilityAI service used by `_stabilityai_stableimage_generator.py`.
+
+## License
+
+The source code is available under the MIT license. See `LICENSE` for details.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
-В этот репозиторий будут выкладываться "скетчи", зачастую возможно не хорошо написанные и/или имеющие какую-то хорошую идею.
-* Image Translator ("Переводчик изображений") - с помощью WINAPI делает скриншот выбранной области экрана, распознает английский текст с помощью OCR, затем переводит его на русский и выводит переведенный текст на экран.
+## О проекте
 
-  Файл `image_translator.py` предполагает, что Tesseract установлен по пути
-  `C:\Program Files\Tesseract-OCR\tesseract.exe`. Если путь к исполняемому
-  файлу другой, отредактируйте переменную `tesseract_cmd` в коде.
+Небольшая коллекция экспериментальных Python‑скриптов. Некоторые из них могут
+быть написаны не самым лучшим образом, но демонстрируют интересные идеи.
+
+* **Image Translator** – при помощи WinAPI делает скриншот выбранной области
+  экрана, распознаёт английский текст через OCR, переводит его на русский и
+  выводит поверх остальных окон.
+
+Англоязычную версию этого файла можно найти в [README.en.md](README.en.md).
+
+## Требования
+
+- Python 3.8 или новее;
+- Windows для работы модуля Image Translator (используется WinAPI);
+- пакеты из `requirements.txt`.
+
+Некоторые подмодули требуют настроенные переменные окружения (см. раздел ниже).
 
 ## Установка зависимостей
 
@@ -12,6 +24,30 @@
 ```bash
 pip install -r requirements.txt
 ```
+
+## Примеры запуска
+
+Image Translator:
+
+```bash
+set TESSERACT_CMD=C:\\Program Files\\Tesseract-OCR\\tesseract.exe
+python dev-image_translator/image_translator.py
+```
+
+Генерация изображений через StabilityAI:
+
+```bash
+set _STABILITYAI_API_KEY_1=your_api_key
+python dev-stability_ai/_stabilityai_stableimage_generator.py
+```
+
+## Переменные окружения
+
+- `TESSERACT_CMD` – путь к исполняемому файлу `tesseract.exe`. Используется
+  модулем *Image Translator*. Если переменная не указана, берётся значение
+  `C:\Program Files\Tesseract-OCR\tesseract.exe`.
+- `_STABILITYAI_API_KEY_1` – API‑ключ для доступа к сервису StabilityAI. Требуется
+  скриптом `_stabilityai_stableimage_generator.py`.
 
 ## Лицензия
 

--- a/dev-image_translator/README.md
+++ b/dev-image_translator/README.md
@@ -17,7 +17,9 @@
 
 - Windows (используется WinAPI через `pywin32`).
 - Для размытия фона требуется Windows 10 или новее.
-- Установленный Tesseract OCR. По умолчанию путь к исполняемому файлу ожидается `C:\\Program Files\\Tesseract-OCR\\tesseract.exe`.
+- Установленный Tesseract OCR. Путь к `tesseract.exe` можно задать через
+  переменную окружения `TESSERACT_CMD`. По умолчанию используется
+  `C:\\Program Files\\Tesseract-OCR\\tesseract.exe`.
 - Python‑пакеты из файла `requirements.txt`.
 
 Установите их командой:

--- a/dev-image_translator/image_translator.py
+++ b/dev-image_translator/image_translator.py
@@ -35,7 +35,10 @@ from math import sin
 
 import pytesseract
 
-pytesseract.pytesseract.tesseract_cmd = r'C:\Program Files\Tesseract-OCR\tesseract.exe'
+# Использовать путь из переменной окружения TESSERACT_CMD, если она задана
+pytesseract.pytesseract.tesseract_cmd = os.environ.get(
+    "TESSERACT_CMD", r"C:\\Program Files\\Tesseract-OCR\\tesseract.exe"
+)
 
 try:
     ctypes.windll.user32.SetProcessDPIAware()

--- a/dev-stability_ai/_stabilityai_stableimage_generator.py
+++ b/dev-stability_ai/_stabilityai_stableimage_generator.py
@@ -228,7 +228,11 @@ class _StabilityAI_StableImage_Generate:
 if __name__ == "__main__":
     import os
 
-    api = _StabilityAI_StableImage_Generate(api_key=os.environ['_STABILITYAI_API_KEY_1'])
+    api_key = os.environ.get("_STABILITYAI_API_KEY_1")
+    if not api_key:
+        raise SystemExit("Set the _STABILITYAI_API_KEY_1 environment variable")
+
+    api = _StabilityAI_StableImage_Generate(api_key=api_key)
 
     img = api.generate(
         prompt="""cinematic detailed 8k illustration of a shy anthro pony girl (no horn) with short soft white


### PR DESCRIPTION
## Summary
- describe project, requirements and usage in Russian README
- add English translation README.en.md
- document `TESSERACT_CMD` and `_STABILITYAI_API_KEY_1`
- make Image Translator and StabilityAI scripts use environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dd84ceae483248dcf605c95aa28d4