### PR TITLE
Improve network robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@
 pip install -r requirements.txt
 ```
 
+## Пример использования ChatHistoryCompressor
+
+```python
+from dev_group_supervisor.chat_history_compressor import ChatHistoryCompressor
+
+compressor = ChatHistoryCompressor(api_key="YOUR_TOKEN")
+try:
+    result = compressor.compress_messages([{"role": "user", "content": "Привет"}], max_model_tokens=4096)
+except requests.RequestException as exc:
+    print("Ошибка запроса:", exc)
+```
+
 ## Лицензия
 
 Исходный код распространяется под лицензией MIT. Подробности в файле `LICENSE`.

--- a/dev-group_supervisor/README.md
+++ b/dev-group_supervisor/README.md
@@ -6,3 +6,21 @@
 истории чата OpenAI. Он сохраняет важные даты и числа и сокращает
 каждый блок, пока история не уместится в две трети лимита токенов
 целевой модели.
+
+## Пример
+
+```python
+from chat_history_compressor import ChatHistoryCompressor
+
+messages = [
+    {"role": "user", "content": "Привет"},
+    {"role": "assistant", "content": "Здравствуйте"},
+]
+
+compressor = ChatHistoryCompressor(api_key="YOUR_TOKEN")
+
+try:
+    short_history = compressor.compress_messages(messages, max_model_tokens=4096)
+except requests.RequestException as exc:
+    print("Ошибка обращения к API:", exc)
+```

--- a/dev-group_supervisor/chat_history_compressor.py
+++ b/dev-group_supervisor/chat_history_compressor.py
@@ -72,8 +72,12 @@ class ChatHistoryCompressor:
             "temperature": 0.1,
         }
         self._log.debug("Requesting DeepSeek compression")
-        resp = requests.post(url, headers=headers, json=payload, timeout=60)
-        resp.raise_for_status()
+        try:
+            resp = requests.post(url, headers=headers, json=payload, timeout=30)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            self._log.error("Ошибка запроса к DeepSeek: %s", exc)
+            raise
         data = resp.json()
         content = data["choices"][0]["message"]["content"]
         return {"role": "system", "content": content.strip()}

--- a/dev-stability_ai/_stabilityai_stableimage_generator.py
+++ b/dev-stability_ai/_stabilityai_stableimage_generator.py
@@ -3,11 +3,14 @@ from enum import Enum
 from typing import Optional, Union, BinaryIO
 import io
 import os
+import logging
 
 try:
     from PIL import Image as PILImage
 except ImportError:
     PILImage = None
+
+log = logging.getLogger(__name__)
 
 class AspectRatio(Enum):
     """Варианты пропорций для генерации изображений."""
@@ -168,28 +171,78 @@ class _StabilityAI_StableImage_Generate:
                     # Передан путь до файла
                     with open(image, "rb") as f:
                         files = {"image": f}
-                        response = requests.post(url, headers=headers, files=files, data=data)
+                        try:
+                            response = requests.post(
+                                url,
+                                headers=headers,
+                                files=files,
+                                data=data,
+                                timeout=30,
+                            )
+                        except requests.RequestException as exc:
+                            log.error("Ошибка запроса к StabilityAI: %s", exc)
+                            raise
                 elif isinstance(image, bytes):
                     # Переданы байты
                     files = {"image": ("image", image)}
-                    response = requests.post(url, headers=headers, files=files, data=data)
+                    try:
+                        response = requests.post(
+                            url,
+                            headers=headers,
+                            files=files,
+                            data=data,
+                            timeout=30,
+                        )
+                    except requests.RequestException as exc:
+                        log.error("Ошибка запроса к StabilityAI: %s", exc)
+                        raise
                 elif hasattr(image, "read"):
                     # Файловый объект (например io.BytesIO)
                     files = {"image": ("image", image.read())}
-                    response = requests.post(url, headers=headers, files=files, data=data)
+                    try:
+                        response = requests.post(
+                            url,
+                            headers=headers,
+                            files=files,
+                            data=data,
+                            timeout=30,
+                        )
+                    except requests.RequestException as exc:
+                        log.error("Ошибка запроса к StabilityAI: %s", exc)
+                        raise
                 elif PILImage and isinstance(image, PILImage.Image):
                     # Объект PIL.Image (Pillow)
                     buf = io.BytesIO()
                     image.save(buf, format="PNG")
                     buf.seek(0)
                     files = {"image": ("image", buf.read())}
-                    response = requests.post(url, headers=headers, files=files, data=data)
+                    try:
+                        response = requests.post(
+                            url,
+                            headers=headers,
+                            files=files,
+                            data=data,
+                            timeout=30,
+                        )
+                    except requests.RequestException as exc:
+                        log.error("Ошибка запроса к StabilityAI: %s", exc)
+                        raise
                 else:
                     raise ValueError("Параметр image должен быть str (путь), bytes, BinaryIO или PIL.Image.Image")
             else:
                 # Для чисто текстовой генерации по требованиям API
                 files = {"none": ""}
-                response = requests.post(url, headers=headers, files=files, data=data)
+                try:
+                    response = requests.post(
+                        url,
+                        headers=headers,
+                        files=files,
+                        data=data,
+                        timeout=30,
+                    )
+                except requests.RequestException as exc:
+                    log.error("Ошибка запроса к StabilityAI: %s", exc)
+                    raise
 
             if response.status_code == 200:
                 current_save = None


### PR DESCRIPTION
## Summary
- handle network errors in chat history compressor
- add logging and timeout to StabilityAI generator
- show usage examples in READMEs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dd85823d48324ae0c7d50da8dc476