### PR TITLE
Add docstrings and type hints

### DIFF
--- a/dev-group_supervisor/chat_history_compressor.py
+++ b/dev-group_supervisor/chat_history_compressor.py
@@ -1,6 +1,4 @@
-"""\
-Утилиты для сжатия длинной истории переписки с использованием DeepSeek Reasoner.
-"""
+"""Utilities for compressing long chat histories using DeepSeek Reasoner."""
 
 from __future__ import annotations
 
@@ -13,9 +11,7 @@ import tiktoken
 
 
 class ChatHistoryCompressor:
-    """\
-    Рекурсивно сжимает историю чата с помощью API DeepSeek Reasoner.
-    """
+    """Recursively compress chat history with the DeepSeek Reasoner API."""
 
     def __init__(self, api_key: str, model: str = "deepseek-chat") -> None:
         self.api_key = api_key
@@ -24,9 +20,7 @@ class ChatHistoryCompressor:
         self._log = logging.getLogger(self.__class__.__name__)
 
     def _count_tokens(self, messages: List[Dict[str, str]]) -> int:
-        """\
-        Подсчитать количество токенов в списке сообщений формата OpenAI.
-        """
+        """Count tokens in a list of OpenAI-formatted messages."""
         tokens_per_message = 4
         tokens_per_name = -1
         total = 0
@@ -38,7 +32,10 @@ class ChatHistoryCompressor:
                     total += tokens_per_name
         return total + 2
 
-    def _split_blocks(self, messages: List[Dict[str, str]], block_token_limit: int) -> List[List[Dict[str, str]]]:
+    def _split_blocks(
+        self, messages: List[Dict[str, str]], block_token_limit: int
+    ) -> List[List[Dict[str, str]]]:
+        """Split messages into blocks not exceeding ``block_token_limit`` tokens."""
         blocks: List[List[Dict[str, str]]] = []
         current: List[Dict[str, str]] = []
         tokens = 0
@@ -56,6 +53,7 @@ class ChatHistoryCompressor:
         return blocks
 
     def _compress_block(self, block: List[Dict[str, str]]) -> Dict[str, str]:
+        """Compress a single block of messages using DeepSeek."""
         text = "\n".join(f"{m['role']}: {m['content']}" for m in block)
         prompt = (
             "Сожми следующие сообщения без потери смысла и важной информации дат "
@@ -78,11 +76,10 @@ class ChatHistoryCompressor:
         content = data["choices"][0]["message"]["content"]
         return {"role": "system", "content": content.strip()}
 
-    def compress_messages(self, messages: List[Dict[str, str]], max_model_tokens: int) -> List[Dict[str, str]]:
-        """\
-        Рекурсивно сжимает ``messages``, чтобы результат занимал не более
-        двух третей от ``max_model_tokens``.
-        """
+    def compress_messages(
+        self, messages: List[Dict[str, str]], max_model_tokens: int
+    ) -> List[Dict[str, str]]:
+        """Recursively compress ``messages`` to fit within two thirds of ``max_model_tokens``."""
         limit = math.floor(max_model_tokens * (2 / 3))
         compressed = list(messages)
         while self._count_tokens(compressed) > limit:

--- a/dev-image_translator/image_translator.py
+++ b/dev-image_translator/image_translator.py
@@ -1,14 +1,13 @@
-"""\
-Утилита для перевода текста, выделяемого на экране.
+"""Utility for translating text selected on the screen.
 
-Модуль предоставляет небольшое окно, следующее за курсором. Когда
-пользователь правой кнопкой мыши выделяет прямоугольную область,
-её содержимое захватывается, распознаётся через OCR и переводится.
-Переведённый текст отображается рядом с курсором.
+The module displays a small window following the cursor. When the user selects
+a rectangular area with the mouse, its contents are captured, recognized via
+OCR and translated. The translated text appears near the cursor.
 """
 
 import sys
 import os
+from typing import Sequence
 from PIL import Image
 
 import ctypes
@@ -46,33 +45,34 @@ except Exception:
 from translate import Translator
 
 class Window:
-    """Вспомогательный класс для управления окном pygame через WinAPI."""
+    """Helper class for controlling the pygame window via the WinAPI."""
 
     hwnd = None
 
     @classmethod
-    def init(cls, hwnd):
-        """Сохраняет дескриптор окна для последующих операций."""
+    def init(cls, hwnd: int) -> None:
+        """Store window handle for further operations."""
         cls.hwnd = hwnd
 
     @classmethod
-    def set_position(cls, x, y):
-        """Перемещает окно в указанную позицию."""
+    def set_position(cls, x: int, y: int) -> None:
+        """Move the window to the given position."""
         win32gui.SetWindowPos(cls.hwnd, win32con.HWND_TOPMOST, x, y, 0, 0, win32con.SWP_NOSIZE)
 
     @classmethod
-    def set_size(cls, w, h):
-        """Изменяет размер окна без перемещения."""
+    def set_size(cls, w: int, h: int) -> None:
+        """Change the window size without moving it."""
         win32gui.SetWindowPos(cls.hwnd, win32con.HWND_TOPMOST, 0, 0, w, h, win32con.SWP_NOMOVE)
 
     @classmethod
-    def make_transparent(cls, color=(0, 0, 0), alpha=255):
-        """Делает окно прозрачным по заданному цвету.
+    def make_transparent(
+        cls, color: tuple[int, int, int] = (0, 0, 0), alpha: int = 255
+    ) -> None:
+        """Make the window transparent using the given color.
 
-        ``alpha`` оставлен для обратной совместимости, но на данный момент
-        окно всегда получает значение прозрачности ``255`` и флаги
-        ``LWA_COLORKEY | LWA_ALPHA``. Это позволяет использовать
-        полупрозрачные поверхности, созданные в ``pygame``.
+        ``alpha`` is kept for backward compatibility but the window is always
+        set to fully opaque with ``LWA_COLORKEY | LWA_ALPHA`` which allows using
+        semi-transparent ``pygame`` surfaces.
         """
         win32gui.SetWindowLong(
             cls.hwnd,
@@ -87,8 +87,8 @@ class Window:
         )
 
     @classmethod
-    def enable_blur(cls):
-        """Включить размытие позади окна, если поддерживается системой."""
+    def enable_blur(cls) -> None:
+        """Enable blur behind the window if supported by the system."""
         if not WINDOWS or cls.hwnd is None:
             return
         try:
@@ -129,8 +129,8 @@ class Window:
                 pass
 
     @classmethod
-    def disable_blur(cls):
-        """Выключить размытие позади окна."""
+    def disable_blur(cls) -> None:
+        """Disable blur behind the window."""
         if not WINDOWS or cls.hwnd is None:
             return
         try:
@@ -170,11 +170,16 @@ class Window:
                 pass
 
 class Screenshot:
-    """Функции для создания скриншотов через WinAPI."""
+    """Utility functions for creating screenshots via the WinAPI."""
 
     @classmethod
-    def grab(cls, rect, bmp_filename=None, hwnd=0):
-        """Захватывает прямоугольную область экрана и сохраняет её в ``bmp_filename``."""
+    def grab(
+        cls,
+        rect: Sequence[int],
+        bmp_filename: str | None = None,
+        hwnd: int = 0,
+    ) -> None:
+        """Capture a rectangular region of the screen and save it to ``bmp_filename``."""
         if bmp_filename is None:
             bmp_filename = os.path.join(os.path.dirname(__file__), "screenshots", "screenshot.bmp")
         window_dc = win32gui.GetWindowDC(hwnd)
@@ -195,8 +200,8 @@ class Screenshot:
         win32gui.DeleteObject(data_bitmap.GetHandle())
 
     @classmethod
-    def grab_image(cls, rect, hwnd=0):
-        """Возвращает :class:`PIL.Image` выбранной области экрана без записи на диск."""
+    def grab_image(cls, rect: Sequence[int], hwnd: int = 0) -> Image.Image:
+        """Return a :class:`PIL.Image` of the selected screen area without saving."""
         window_dc = win32gui.GetWindowDC(hwnd)
         dc_object = win32ui.CreateDCFromHandle(window_dc)
         compatible_dc = dc_object.CreateCompatibleDC()
@@ -218,9 +223,9 @@ class Screenshot:
         return Image.frombuffer('RGB', (bmp_info['bmWidth'], bmp_info['bmHeight']), bmp_str, 'raw', 'BGRX', 0, 1)
 
 class ImageTranslatorApp:
-    """Интерактивное приложение для перевода выделений на экране."""
+    """Interactive application for translating selections on the screen."""
 
-    def __init__(self, debug=False):
+    def __init__(self, debug: bool = False) -> None:
         import pygame
 
         self.debug = debug
@@ -264,13 +269,13 @@ class ImageTranslatorApp:
         ).start()
         mouse.Listener(on_move=self.on_move).start()
 
-    def update_drag_rect(self):
-        """Пересчитать текущий прямоугольник выделения на основе ``self.drag_points``."""
+    def update_drag_rect(self) -> None:
+        """Recalculate ``self.current_drag_rect`` from ``self.drag_points``."""
         x1, y1, x2, y2 = self.drag_points
         self.current_drag_rect = [min(x1, x2), min(y1, y2), abs(x2 - x1), abs(y2 - y1)]
 
     def _set_blur(self, enable: bool) -> None:
-        """Включить или отключить размытие в зависимости от ``enable``."""
+        """Enable or disable blur depending on ``enable``."""
         if enable and not self.blur_enabled:
             Window.enable_blur()
             self.blur_enabled = True
@@ -278,8 +283,8 @@ class ImageTranslatorApp:
             Window.disable_blur()
             self.blur_enabled = False
 
-    def process_selection(self, selected_rect, proc_id):
-        """Распознаёт текст из ``selected_rect`` и переводит его."""
+    def process_selection(self, selected_rect: Sequence[int], proc_id: int) -> None:
+        """Recognize text from ``selected_rect`` and translate it."""
         img = Screenshot.grab_image(selected_rect)
         if self.debug:
             try:
@@ -292,13 +297,12 @@ class ImageTranslatorApp:
             self.pending_text = result
 
     # Обработчики событий -----------------------------------------------------
-    def on_move(self, x, y):
-        """Отслеживать перемещение курсора во время выделения.
+    def on_move(self, x: int, y: int) -> bool:
+        """Track mouse movement during selection.
 
-        ``pynput`` уже отдаёт глобальные координаты, но мы дополнительно
-        запрашиваем положение курсора через ``win32api``, чтобы начальная и
-        конечная точки всегда были относительно всего экрана, независимо
-        от положения окна.
+        ``pynput`` already provides global coordinates, but we additionally
+        query the cursor position via ``win32api`` so that start and end points
+        are always relative to the entire screen.
         """
         if self.pressed:
             sx, sy = win32api.GetCursorPos()
@@ -307,16 +311,16 @@ class ImageTranslatorApp:
         return not self.done
 
 
-    def start_selection(self):
-        """Начать выделение при нажатии горячих клавиш."""
+    def start_selection(self) -> None:
+        """Begin a selection when the hotkeys are pressed."""
         sx, sy = win32api.GetCursorPos()
         self.drag_points[0:4] = [sx, sy, sx, sy]
         self.update_drag_rect()
         self.rect[0:2] = [sx, sy]
         self.pressed = True
 
-    def finish_selection(self):
-        """Завершить выделение после отпускания горячих клавиш."""
+    def finish_selection(self) -> None:
+        """Finish the selection after the hotkeys are released."""
         sx, sy = win32api.GetCursorPos()
         self.drag_points[2:] = [sx, sy]
         self.update_drag_rect()
@@ -340,8 +344,8 @@ class ImageTranslatorApp:
 
         self.pressed = False
 
-    def on_key_press(self, key):
-        """Отслеживать нажатия клавиш для запуска выделения."""
+    def on_key_press(self, key) -> bool:
+        """Handle key presses to start a selection."""
         if key in (keyboard.Key.ctrl_l, keyboard.Key.ctrl_r):
             self.key_state.add("ctrl")
         if key in (keyboard.Key.alt_l, keyboard.Key.alt_r):
@@ -351,8 +355,8 @@ class ImageTranslatorApp:
             self.start_selection()
         return not self.done
 
-    def on_key_release(self, key):
-        """Отслеживать отпускание клавиш для завершения выделения."""
+    def on_key_release(self, key) -> bool:
+        """Handle key releases to finish the selection."""
         if key in (keyboard.Key.ctrl_l, keyboard.Key.ctrl_r):
             self.key_state.discard("ctrl")
         if key in (keyboard.Key.alt_l, keyboard.Key.alt_r):
@@ -363,7 +367,7 @@ class ImageTranslatorApp:
         return not self.done
 
     # Основной цикл ----------------------------------------------------------
-    def run(self):
+    def run(self) -> None:
         pygame = self.pygame
         while not self.done:
             self.cursor_position = win32api.GetCursorPos()
@@ -430,8 +434,8 @@ class ImageTranslatorApp:
         pygame.quit()
 
 
-def main(argv=None):
-    """Точка входа при запуске как скрипта."""
+def main(argv: Sequence[str] | None = None) -> None:
+    """Entry point when executed as a script."""
     import argparse
 
     parser = argparse.ArgumentParser(description="Translate screen selections")

--- a/dev-stability_ai/_stabilityai_stableimage_generator.py
+++ b/dev-stability_ai/_stabilityai_stableimage_generator.py
@@ -10,7 +10,7 @@ except ImportError:
     PILImage = None
 
 class AspectRatio(Enum):
-    """Варианты пропорций для генерации изображений."""
+    """Aspect ratio options for image generation."""
     AR_16_9 = "16:9"
     AR_1_1 = "1:1"
     AR_21_9 = "21:9"
@@ -22,19 +22,19 @@ class AspectRatio(Enum):
     AR_9_21 = "9:21"
 
 class OutputFormat(Enum):
-    """Варианты формата вывода изображения."""
+    """Available output image formats."""
     JPEG = "jpeg"
     PNG = "png"
     WEBP = "webp"
 
 class ModelType(Enum):
-    """Тип модели генерации Stable Diffusion."""
+    """Stable Diffusion model type."""
     ULTRA = "ultra"
     CORE = "core"
     SD3 = "sd3"
 
 class StylePreset(Enum):
-    """Варианты стилей генерации (style_preset) из Stability API."""
+    """Style presets from the Stability API."""
     THREE_D_MODEL = "3d-model"
     ANALOG_FILM = "analog-film"
     ANIME = "anime"
@@ -55,11 +55,7 @@ class StylePreset(Enum):
 
 
 class _StabilityAI_StableImage_Generate:
-    """
-    Класс для взаимодействия с REST API StabilityAI (v2beta) — генерация изображений.
-
-    Позволяет генерировать изображения по текстовому описанию через разные модели Stable Diffusion.
-    """
+    """Client for the StabilityAI REST API (v2beta) for image generation."""
 
     BASE_URL = "https://api.stability.ai/v2beta/stable-image/generate"
 
@@ -70,14 +66,13 @@ class _StabilityAI_StableImage_Generate:
         client_user_id: Optional[str] = None,
         client_version: Optional[str] = None,
     ):
-        """
-        Инициализация клиента для API Stable Diffusion.
+        """Initialize the client for the Stable Diffusion API.
 
         Args:
-            api_key (str): Ваш API-ключ StabilityAI (обязательно).
-            client_id (Optional[str]): ID вашего приложения (опционально).
-            client_user_id (Optional[str]): Уникальный идентификатор пользователя (опционально).
-            client_version (Optional[str]): Версия вашего клиента (опционально).
+            api_key: Your StabilityAI API key.
+            client_id: Optional application identifier.
+            client_user_id: Optional unique user identifier.
+            client_version: Optional client version string.
         """
         self.api_key = api_key
         self.client_id = client_id
@@ -100,36 +95,34 @@ class _StabilityAI_StableImage_Generate:
         save_path: Optional[str] = None,
         return_type: str = "bytes",
     ) -> Union[bytes, str, BinaryIO, "PILImage.Image", list]:
-        """
-        Генерирует изображение по текстовому описанию через REST API StabilityAI.
+        """Generate an image from ``prompt`` using the StabilityAI REST API.
 
         Args:
-            prompt (str): Описательный текстовый запрос (обязательно).
-            model (ModelType): Модель генерации (ultra, core, sd3).
-            negative_prompt (Optional[str]): Текст того, чего не должно быть на изображении (опционально).
-            aspect_ratio (Optional[AspectRatio]): Пропорция изображения (опционально).
-            seed (Optional[int]): Число для детерминированной генерации; если None, результат случайный (опционально).
-        output_format (OutputFormat): Формат выдаваемого изображения (webp, png, jpeg).
-        samples (int): Количество изображений для генерации.
-        image (Optional[Union[str, bytes, BinaryIO, PILImage.Image]]):
-                Исходное изображение для режимов img2img/inpainting.
-                Можно передать путь до файла (str), байты (bytes), файловый объект (BinaryIO) или объект PIL.Image (Pillow).
-            style_preset (Optional[str]): Предустановленный стиль (опционально, см. документацию StabilityAI).
-            strength (Optional[float]): Сила изменения исходного изображения (0..1, только для img2img/inpainting).
-            accept (str): Тип возвращаемых данных от API — "image/*" (байты) или "application/json" (base64) (обычно не менять).
-            save_path (Optional[str]): Если указан, результат сохраняется по этому пути (опционально).
-            return_type (str): Формат результата: "bytes" (байты, по умолчанию),
-                "str" (путь к файлу, только с save_path), "BinaryIO" (io.BytesIO), "PIL" (PIL.Image.Image).
+            prompt: Text prompt for generation.
+            model: Generation model to use.
+            negative_prompt: Text that must not appear in the image.
+            aspect_ratio: Desired aspect ratio of the result.
+            seed: Seed for deterministic generation or ``None`` for random.
+            output_format: Output image format.
+            samples: Number of images to generate.
+            image: Optional source image for img2img/inpainting. Can be a path,
+                bytes, a file-like object or ``PIL.Image``.
+            style_preset: Optional style preset.
+            strength: Strength of modification for img2img mode.
+            accept: Response type, usually not changed.
+            save_path: Optional path to save the result.
+            return_type: Result format: ``"bytes"`` (default), ``"str"`` (path with
+                ``save_path``), ``"BinaryIO"`` or ``"PIL"``.
 
         Returns:
-            bytes | list: Если return_type="bytes". При samples>1 возвращается список.
-            str | list: Путь к файлам, если return_type="str" и указан save_path. При samples>1 список путей.
-            io.BytesIO | list: Если return_type="BinaryIO". При samples>1 список объектов.
-            PIL.Image.Image | list: Если return_type="PIL" и установлен Pillow. При samples>1 список изображений.
+            bytes | list: When ``return_type="bytes"``. List if ``samples > 1``.
+            str | list: Path(s) when ``return_type="str"`` and ``save_path`` is set.
+            io.BytesIO | list: When ``return_type="BinaryIO"``.
+            PIL.Image.Image | list: When ``return_type="PIL"``.
 
         Raises:
-            ValueError: Если передан некорректный тип изображения или return_type.
-            Exception: При ошибке API возвращается текст ошибки.
+            ValueError: If an invalid image type or ``return_type`` is provided.
+            Exception: Raised when the API returns an error.
         """
         url = f"{self.BASE_URL}/{model.value}"
 


### PR DESCRIPTION
## Summary
- translate module and class docstrings to English
- clarify function parameter types and return annotations
- keep Russian inline comments where present

## Testing
- `python -m py_compile dev-group_supervisor/chat_history_compressor.py dev-image_translator/image_translator.py dev-stability_ai/_stabilityai_stableimage_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_684dd877a3e08324ab8db5a44aba798f