### PR TITLE
Add TP/SL fields and implement break-even stop automation

### DIFF
--- a/dev-crypto_trader/crypto_trader.py
+++ b/dev-crypto_trader/crypto_trader.py
@@ -155,6 +155,8 @@ class CryptoTraderApp(BaseApp):
         move_sl_to_be = bool(payload.get("move_sl_to_be"))
         quantity_text = (payload.get("quantity") or "").replace(",", ".").strip()
         price_text = (payload.get("price") or "").replace(",", ".").strip()
+        take_profit_text = (payload.get("take_profit") or "").replace(",", ".").strip()
+        stop_loss_text = (payload.get("stop_loss") or "").replace(",", ".").strip()
 
         quantity_value: Optional[float] = None
         if quantity_text:
@@ -165,6 +167,28 @@ class CryptoTraderApp(BaseApp):
                 return
             if quantity_value <= 0:
                 self._append_status("Количество должно быть больше нуля")
+                return
+
+        take_profit_value: Optional[float] = None
+        if take_profit_text:
+            try:
+                take_profit_value = float(take_profit_text)
+            except ValueError:
+                self._append_status(f"Некорректный тейк-профит: {take_profit_text}")
+                return
+            if take_profit_value <= 0:
+                self._append_status("Тейк-профит должен быть больше нуля")
+                return
+
+        stop_loss_value: Optional[float] = None
+        if stop_loss_text:
+            try:
+                stop_loss_value = float(stop_loss_text)
+            except ValueError:
+                self._append_status(f"Некорректный стоп-лосс: {stop_loss_text}")
+                return
+            if stop_loss_value <= 0:
+                self._append_status("Стоп-лосс должен быть больше нуля")
                 return
 
         with self.state["lock"]:
@@ -191,6 +215,8 @@ class CryptoTraderApp(BaseApp):
                     quantity=quantity_value,
                     reduce_only=reduce_only,
                     move_sl_to_be=move_sl_to_be,
+                    take_profit=take_profit_value,
+                    stop_loss=stop_loss_value,
                 )
 
             threading.Thread(target=worker, daemon=True).start()
@@ -205,6 +231,8 @@ class CryptoTraderApp(BaseApp):
                 quantity=quantity_value,
                 reduce_only=reduce_only,
                 move_sl_to_be=move_sl_to_be,
+                take_profit=take_profit_value,
+                stop_loss=stop_loss_value,
             )
 
         threading.Thread(target=worker, daemon=True).start()

--- a/dev-crypto_trader/futures_trader.py
+++ b/dev-crypto_trader/futures_trader.py
@@ -191,6 +191,15 @@ class BinanceFuturesClient:
         response.raise_for_status()
         return response.json()
 
+    def public_get(self, path: str, params: Optional[Dict[str, str]] = None) -> Dict:
+        response = self.session.get(
+            f"{self.config.base_url}{path}",
+            params=params,
+            timeout=self.config.timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
     # -- higher level helpers ---------------------------------------------
     def place_market_order(self, symbol: str, side: str, quantity: str, reduce_only: bool = False) -> Dict:
         return self.place_order(symbol, side, "MARKET", quantity, reduce_only=reduce_only)
@@ -241,6 +250,27 @@ class BinanceFuturesClient:
             params["reduceOnly"] = "true"
         return self.post("/fapi/v1/order", params)
 
+    def place_exit_order(self, symbol: str, side: str, order_type: str, stop_price: str) -> Dict:
+        params = {
+            "symbol": symbol,
+            "side": side,
+            "type": order_type,
+            "stopPrice": stop_price,
+            "closePosition": "true",
+            "timestamp": str(int(time.time() * 1000)),
+        }
+        return self.post("/fapi/v1/order", params)
+
+    def get_position_risk(self) -> List[Dict]:
+        params = {"timestamp": str(int(time.time() * 1000))}
+        data = self.get("/fapi/v2/positionRisk", params)
+        if isinstance(data, list):
+            return data
+        return []
+
+    def get_symbol_info(self, symbol: str) -> Dict:
+        return self.public_get("/fapi/v1/exchangeInfo", {"symbol": symbol})
+
     def get_balances(self):
         params = {
             "timestamp": str(int(time.time() * 1000)),
@@ -269,6 +299,7 @@ class DemoFuturesTrader:
         self.state = state
         self._lock = threading.Lock()
         self._client: Optional[BinanceFuturesClient] = None
+        self._symbol_tick_cache: Dict[str, Optional[float]] = {}
         config = BinanceFuturesConfig.from_env()
         if config is None:
             _log_to_state(
@@ -361,6 +392,176 @@ class DemoFuturesTrader:
             return None
         return self._determine_quantity(symbol, price)
 
+    def _closing_side(self, side: str) -> str:
+        return "SELL" if side.upper() == "BUY" else "BUY"
+
+    def _handle_exit_orders(
+        self,
+        symbol: str,
+        side: str,
+        *,
+        take_profit: Optional[float],
+        stop_loss: Optional[float],
+        move_sl_to_be: bool,
+    ) -> None:
+        if not (take_profit or stop_loss or move_sl_to_be):
+            return
+        if not self.is_enabled():
+            _log_to_state(
+                self.state,
+                "Невозможно создать тейк-профит/стоп-лосс без API ключей Binance",
+            )
+            return
+        if take_profit is not None:
+            self._place_take_profit(symbol, side, take_profit)
+        if stop_loss is not None:
+            self._place_stop_loss(symbol, side, stop_loss)
+        if move_sl_to_be:
+            self._schedule_break_even_stop(symbol, side)
+
+    def _submit_exit_order(
+        self,
+        symbol: str,
+        side: str,
+        order_type: str,
+        price_value: float,
+        label: str,
+    ) -> bool:
+        if price_value <= 0:
+            _log_to_state(self.state, f"Не удалось создать {label} {symbol}: цена должна быть положительной")
+            return False
+        formatted = self._format_price(price_value)
+        with self._lock:
+            assert self._client is not None
+            try:
+                self._client.place_exit_order(symbol, side, order_type, formatted)
+            except requests.HTTPError as exc:
+                try:
+                    payload = exc.response.json()
+                    message = payload.get("msg") if isinstance(payload, dict) else str(payload)
+                except Exception:
+                    message = str(exc)
+                _log_to_state(self.state, f"Биржа отклонила {label} {symbol}: {message}")
+                return False
+            except Exception as exc:
+                _log_to_state(self.state, f"Ошибка отправки {label} {symbol}: {exc}")
+                return False
+        _log_to_state(self.state, f"Создан {label} {symbol}: цена {formatted}")
+        return True
+
+    def _place_take_profit(self, symbol: str, side: str, price: float) -> None:
+        closing_side = self._closing_side(side)
+        self._submit_exit_order(symbol, closing_side, "TAKE_PROFIT_MARKET", price, "тейк-профит")
+
+    def _place_stop_loss(self, symbol: str, side: str, price: float) -> None:
+        closing_side = self._closing_side(side)
+        self._submit_exit_order(symbol, closing_side, "STOP_MARKET", price, "стоп-лосс")
+
+    def _get_tick_size(self, symbol: str) -> Optional[float]:
+        if symbol in self._symbol_tick_cache:
+            return self._symbol_tick_cache[symbol]
+        if not self.is_enabled():
+            self._symbol_tick_cache[symbol] = None
+            return None
+        assert self._client is not None
+        try:
+            info = self._client.get_symbol_info(symbol)
+        except Exception as exc:  # pragma: no cover - network errors
+            _log_to_state(self.state, f"Не удалось получить шаг цены {symbol}: {exc}")
+            self._symbol_tick_cache[symbol] = None
+            return None
+        tick: Optional[float] = None
+        if isinstance(info, dict):
+            symbols = info.get("symbols")
+            item = None
+            if isinstance(symbols, list) and symbols:
+                item = next((entry for entry in symbols if entry.get("symbol") == symbol), symbols[0])
+            elif info.get("symbol") == symbol:
+                item = info
+            if isinstance(item, dict):
+                for filt in item.get("filters", []):
+                    if filt.get("filterType") == "PRICE_FILTER":
+                        try:
+                            raw = float(filt.get("tickSize"))
+                        except (TypeError, ValueError):
+                            raw = None
+                        else:
+                            if raw and raw > 0:
+                                tick = raw
+                        break
+        if tick is None:
+            _log_to_state(self.state, f"Не удалось определить шаг цены для {symbol}")
+        self._symbol_tick_cache[symbol] = tick
+        return tick
+
+    def _break_even_price(self, symbol: str, entry_price: float, side: str) -> Optional[float]:
+        if entry_price <= 0:
+            return None
+        tick = self._get_tick_size(symbol)
+        if tick and tick > 0:
+            if side.upper() == "BUY":
+                return entry_price + tick
+            candidate = entry_price - tick
+            return candidate if candidate > 0 else max(tick, entry_price * 0.99)
+        adjustment = max(entry_price * 0.001, 0.0001)
+        if side.upper() == "BUY":
+            return entry_price + adjustment
+        candidate = entry_price - adjustment
+        return candidate if candidate > 0 else entry_price * 0.99
+
+    def _schedule_break_even_stop(self, symbol: str, side: str) -> None:
+        assert self._client is not None
+
+        def worker() -> None:
+            attempts = 120
+            while attempts > 0:
+                time.sleep(5)
+                try:
+                    positions = self._client.get_position_risk()
+                except Exception as exc:  # pragma: no cover - network errors
+                    _log_to_state(self.state, f"Не удалось получить позиции для {symbol}: {exc}")
+                    return
+                position = next((item for item in positions if item.get("symbol") == symbol), None)
+                if not position:
+                    attempts -= 1
+                    continue
+                try:
+                    position_amt = float(position.get("positionAmt") or 0.0)
+                    entry_price = float(position.get("entryPrice") or 0.0)
+                    unrealized = float(position.get("unRealizedProfit") or 0.0)
+                except (TypeError, ValueError):
+                    attempts -= 1
+                    continue
+                if side.upper() == "BUY" and position_amt <= 0:
+                    attempts -= 1
+                    continue
+                if side.upper() == "SELL" and position_amt >= 0:
+                    attempts -= 1
+                    continue
+                if entry_price <= 0:
+                    attempts -= 1
+                    continue
+                if unrealized <= 0:
+                    attempts -= 1
+                    continue
+                stop_price = self._break_even_price(symbol, entry_price, side)
+                if stop_price is None:
+                    _log_to_state(self.state, f"Не удалось рассчитать цену безубытка для {symbol}")
+                    return
+                closing_side = self._closing_side(side)
+                if self._submit_exit_order(
+                    symbol,
+                    closing_side,
+                    "STOP_MARKET",
+                    stop_price,
+                    "стоп-лосс (безубыток)",
+                ):
+                    return
+                attempts -= 1
+            _log_to_state(self.state, f"Не удалось перенести SL в безубыток для {symbol}: позиция не приносит прибыль")
+
+        threading.Thread(target=worker, daemon=True).start()
+
     def _log_balances_async(self) -> None:
         if not self.is_enabled():
             return
@@ -398,6 +599,8 @@ class DemoFuturesTrader:
         quantity: Optional[float] = None,
         reduce_only: bool = False,
         move_sl_to_be: bool = False,
+        take_profit: Optional[float] = None,
+        stop_loss: Optional[float] = None,
     ) -> None:
         if not self.is_enabled():
             _log_to_state(self.state, "Демо торговля недоступна: нет API ключей")
@@ -472,6 +675,13 @@ class DemoFuturesTrader:
             price=price_str,
             status="Исполнен",
         )
+        self._handle_exit_orders(
+            symbol,
+            side,
+            take_profit=take_profit,
+            stop_loss=stop_loss,
+            move_sl_to_be=move_sl_to_be,
+        )
 
     def place_limit_order(
         self,
@@ -482,6 +692,8 @@ class DemoFuturesTrader:
         quantity: Optional[float] = None,
         reduce_only: bool = False,
         move_sl_to_be: bool = False,
+        take_profit: Optional[float] = None,
+        stop_loss: Optional[float] = None,
     ) -> None:
         if not self.is_enabled():
             _log_to_state(self.state, "Демо торговля недоступна: нет API ключей")
@@ -554,6 +766,13 @@ class DemoFuturesTrader:
             quantity=qty_value,
             price=price_formatted,
             status=status,
+        )
+        self._handle_exit_orders(
+            symbol,
+            side,
+            take_profit=take_profit,
+            stop_loss=stop_loss,
+            move_sl_to_be=move_sl_to_be,
         )
 
     def update_demo_balance(self, asset: str, amount: float) -> None:

--- a/dev-crypto_trader/ui_elements.py
+++ b/dev-crypto_trader/ui_elements.py
@@ -529,6 +529,8 @@ class OrderDialog(GUIElement):
 
         self.quantity_input = TextInput(self._quantity_rect(), small_font, placeholder="")
         self.price_input = TextInput(self._price_rect(), small_font, placeholder="")
+        self.take_profit_input = TextInput(self._take_profit_rect(), small_font, placeholder="")
+        self.stop_loss_input = TextInput(self._stop_loss_rect(), small_font, placeholder="")
         self.confirm_button = Button(self._confirm_button_rect(), "Отправить", small_font)
         self.cancel_button = Button(self._cancel_button_rect(), "Отмена", small_font)
         self.on_submit: Optional[Callable[[dict], None]] = None
@@ -551,14 +553,20 @@ class OrderDialog(GUIElement):
             self.price_input.set_text(f"{last_price:.4f}")
         else:
             self.price_input.set_text("")
+        self.take_profit_input.set_text("")
+        self.stop_loss_input.set_text("")
         self.quantity_input.active = False
         self.price_input.active = False
+        self.take_profit_input.active = False
+        self.stop_loss_input.active = False
         self._sync_layout()
 
     def close(self) -> None:
         self.visible = False
         self.quantity_input.active = False
         self.price_input.active = False
+        self.take_profit_input.active = False
+        self.stop_loss_input.active = False
         self._order_type_dropdown_open = False
 
     def handle_event(self, event: pygame.event.Event) -> bool:
@@ -616,6 +624,10 @@ class OrderDialog(GUIElement):
             return True
         if self.order_type == "LIMIT" and self.price_input.handle_event(event):
             return True
+        if self.take_profit_input.handle_event(event):
+            return True
+        if self.stop_loss_input.handle_event(event):
+            return True
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             if self._side_rect("BUY").collidepoint(event.pos):
@@ -640,6 +652,8 @@ class OrderDialog(GUIElement):
                 "price": self.price_input.text.strip(),
                 "reduce_only": self.reduce_only,
                 "move_sl_to_be": self.move_sl_to_be,
+                "take_profit": self.take_profit_input.text.strip(),
+                "stop_loss": self.stop_loss_input.text.strip(),
             }
             if self.on_submit:
                 self.on_submit(payload)
@@ -709,8 +723,7 @@ class OrderDialog(GUIElement):
             surface.set_clip(scroll_area)
 
         quantity_lbl = self.small_font.render("Количество", True, (180, 180, 190))
-        quantity_y = max(self._quantity_rect().y - 22, scroll_area.y + 4)
-        surface.blit(quantity_lbl, (self._content_x(), quantity_y))
+        surface.blit(quantity_lbl, (self._content_x(), self._quantity_rect().y - 26))
         self.quantity_input.draw(surface)
 
         if self.order_type == "LIMIT":
@@ -718,10 +731,15 @@ class OrderDialog(GUIElement):
             surface.blit(price_lbl, (self._content_x(), self._price_rect().y - 26))
             self.price_input.draw(surface)
 
+        tp_lbl = self.small_font.render("Тейк-профит", True, (180, 180, 190))
+        surface.blit(tp_lbl, (self._content_x(), self._take_profit_rect().y - 26))
+        self.take_profit_input.draw(surface)
+
+        sl_lbl = self.small_font.render("Стоп-лосс", True, (180, 180, 190))
+        surface.blit(sl_lbl, (self._content_x(), self._stop_loss_rect().y - 26))
+        self.stop_loss_input.draw(surface)
+
         reduce_rect = self._reduce_only_rect()
-        tp_sl_label = self.small_font.render("TP/SL", True, (180, 180, 190))
-        tp_sl_label_y = max(reduce_rect.y - 24, scroll_area.y + 4)
-        surface.blit(tp_sl_label, (self._content_x(), tp_sl_label_y))
         pygame.draw.rect(surface, (40, 45, 60), reduce_rect, border_radius=4)
         if self.reduce_only:
             pygame.draw.rect(surface, (120, 180, 120), reduce_rect.inflate(-6, -6), border_radius=3)
@@ -849,6 +867,14 @@ class OrderDialog(GUIElement):
         top = self._base_price_top() - self.scroll_offset
         return pygame.Rect(self._content_x(), top, self._content_width(), self.input_height)
 
+    def _take_profit_rect(self) -> pygame.Rect:
+        top = self._base_take_profit_top() - self.scroll_offset
+        return pygame.Rect(self._content_x(), top, self._content_width(), self.input_height)
+
+    def _stop_loss_rect(self) -> pygame.Rect:
+        top = self._base_stop_loss_top() - self.scroll_offset
+        return pygame.Rect(self._content_x(), top, self._content_width(), self.input_height)
+
     def _cancel_button_rect(self) -> pygame.Rect:
         width = 150
         height = 36
@@ -865,6 +891,8 @@ class OrderDialog(GUIElement):
         self.scroll_offset = max(0, min(self.scroll_offset, self._max_scroll()))
         self.quantity_input.rect = self._quantity_rect()
         self.price_input.rect = self._price_rect()
+        self.take_profit_input.rect = self._take_profit_rect()
+        self.stop_loss_input.rect = self._stop_loss_rect()
         self.cancel_button.rect = self._cancel_button_rect()
         self.confirm_button.rect = self._confirm_button_rect()
 
@@ -874,11 +902,17 @@ class OrderDialog(GUIElement):
     def _base_price_top(self) -> int:
         return self._base_quantity_top() + self.input_height + 44
 
-    def _base_reduce_only_top(self) -> int:
-        top = self._base_quantity_top() + self.input_height + 24
+    def _base_take_profit_top(self) -> int:
+        top = self._base_quantity_top() + self.input_height + 44
         if self.order_type == "LIMIT":
-            top = self._base_price_top() + self.input_height + 24
+            top = self._base_price_top() + self.input_height + 44
         return top
+
+    def _base_stop_loss_top(self) -> int:
+        return self._base_take_profit_top() + self.input_height + 44
+
+    def _base_reduce_only_top(self) -> int:
+        return self._base_stop_loss_top() + self.input_height + 24
 
     def _base_move_sl_top(self) -> int:
         return self._base_reduce_only_top() + 44


### PR DESCRIPTION
## Summary
- add dedicated take-profit and stop-loss inputs to the order dialog, remove the TP/SL caption, and align the quantity label with its field
- validate and forward optional take-profit and stop-loss prices from the dialog to the trader workflows
- extend the futures trader to submit TP/SL exit orders and asynchronously move the stop-loss to break-even using Binance API data, including tick-size lookups

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_690ba61b2d74832494b39aa12dc5149e